### PR TITLE
Use is_standard_layout && is_trivial over is_pod

### DIFF
--- a/SmallVector.h
+++ b/SmallVector.h
@@ -48,6 +48,11 @@ namespace llvm_vecsmall {
 
 namespace llvm_vecsmall {
 
+// std::is_pod has been deprecated in C++20.
+template <typename T>
+struct IsPod : std::integral_constant<bool, std::is_standard_layout<T>::value &&
+                                                std::is_trivial<T>::value> {};
+
 /// This is all the non-templated stuff common to all SmallVectors.
 class SmallVectorBase {
 protected:
@@ -334,10 +339,11 @@ public:
 /// This class consists of common code factored out of the SmallVector class to
 /// reduce code duplication based on the SmallVector 'N' template parameter.
 template <typename T>
-class SmallVectorImpl : public SmallVectorTemplateBase<T, std::is_pod<T>::value> {
-  typedef SmallVectorTemplateBase<T, std::is_pod<T>::value > SuperClass;
+class SmallVectorImpl : public SmallVectorTemplateBase<T, IsPod<T>::value> {
+  typedef SmallVectorTemplateBase<T, IsPod<T>::value> SuperClass;
 
-  SmallVectorImpl(const SmallVectorImpl&) = delete;
+  SmallVectorImpl(const SmallVectorImpl &) = delete;
+
 public:
   typedef typename SuperClass::iterator iterator;
   typedef typename SuperClass::const_iterator const_iterator;
@@ -346,8 +352,7 @@ public:
 protected:
   // Default ctor - Initialize to empty.
   explicit SmallVectorImpl(unsigned N)
-    : SmallVectorTemplateBase<T, std::is_pod<T>::value>(N*sizeof(T)) {
-  }
+      : SmallVectorTemplateBase<T, IsPod<T>::value>(N * sizeof(T)) {}
 
 public:
   ~SmallVectorImpl() {

--- a/SmallVector.h
+++ b/SmallVector.h
@@ -342,7 +342,7 @@ template <typename T>
 class SmallVectorImpl : public SmallVectorTemplateBase<T, IsPod<T>::value> {
   typedef SmallVectorTemplateBase<T, IsPod<T>::value> SuperClass;
 
-  SmallVectorImpl(const SmallVectorImpl &) = delete;
+  SmallVectorImpl(const SmallVectorImpl&) = delete;
 
 public:
   typedef typename SuperClass::iterator iterator;
@@ -352,7 +352,8 @@ public:
 protected:
   // Default ctor - Initialize to empty.
   explicit SmallVectorImpl(unsigned N)
-      : SmallVectorTemplateBase<T, IsPod<T>::value>(N * sizeof(T)) {}
+    : SmallVectorTemplateBase<T, IsPod<T>::value>(N*sizeof(T)) {
+  }
 
 public:
   ~SmallVectorImpl() {


### PR DESCRIPTION
`std::is_pod` has been deprecated in C++20, so this patch creates an `IsPod` trait that defaults to `std::is_standard_layout && std::is_trivial`, as suggested by GCC:

```
template<class _Tp> struct std::is_pod’ is deprecated: 
use is_standard_layout && is_trivial instead [-Werror=deprecated-declarations]
```